### PR TITLE
Improve homepage SEO and add Schema.org Person JSON-LD

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,10 +10,10 @@ lang: en
 timezone: Europe/Berlin
 
 # SEO Settings
-title: Dr. Lu Hao
-tagline: Condensed-matter physicist
+title: Hao Lu | Physicist
+tagline: Official homepage of Hao Lu (Lu Hao), physicist in Giessen
 description: >-
-  Research focus: VO₂ and correlated oxides, thin films, metal–insulator transitions, structure–property relations.
+  Official academic homepage of Hao Lu (Lu Hao), physicist in Giessen. Research focus: VO₂ thin films, correlated oxides, metal–insulator transitions, and materials physics.
 
 # Website URL
 url: "https://LuHao95CN.github.io"

--- a/index.html
+++ b/index.html
@@ -1,11 +1,47 @@
 ---
 layout: page
 permalink: /
+title: Hao Lu | Physicist (Official Homepage)
+description: Official academic homepage of Hao Lu (Lu Hao), physicist in Giessen, focusing on VO₂ thin films, metal–insulator transition, and materials physics.
 ---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Hao Lu",
+  "alternateName": ["Lu Hao", "Hao LU", "陆昊"],
+  "url": "{{ '/' | absolute_url }}",
+  "image": "{{ '/assets/assets/LuHao.jpg' | absolute_url }}",
+  "jobTitle": "Physicist",
+  "description": "Physicist working on VO₂ thin films, metal-insulator transition, and materials physics.",
+  "knowsAbout": [
+    "VO₂ thin films",
+    "vanadium dioxide",
+    "metal-insulator transition",
+    "materials physics",
+    "condensed matter physics"
+  ],
+  "affiliation": {
+    "@type": "CollegeOrUniversity",
+    "name": "Justus Liebig University Giessen"
+  },
+  "sameAs": [
+    "https://github.com/LuHao95CN",
+    "{{ '/' | absolute_url }}"
+  ]
+}
+</script>
 
 <section class="featured-gallery" aria-label="置顶图片展示">
   <div class="featured-gallery-header">
     <h2>Overview</h2>
+    <p>
+      This is the official homepage of <strong>Hao Lu (Lu Hao)</strong>, a
+      <strong>physicist</strong> based in <strong>Giessen</strong> working on
+      <strong>VO₂ thin films</strong>, metal–insulator transition, and
+      <strong>materials physics</strong>.
+    </p>
   </div>
 
   <div class="featured-gallery-track-wrap">


### PR DESCRIPTION
### Motivation
- Help Google identify this site as the official academic homepage for Hao Lu (Lu Hao) so queries like `Hao LU physicist` or `Lu Hao Giessen` are more likely to surface this site.
- Provide stronger machine-readable identity signals (explicit names, alternate names, affiliation, topics) so entity matching and ranking for branded/academic queries improve.
- Make the homepage text and metadata explicitly include target keywords (name variants, role, affiliation, research topics) to increase relevance for those queries.

### Description
- Updated `_config.yml` SEO fields (`title`, `tagline`, `description`) to include full name, role, affiliation and research keywords such as `VO₂ thin films`, `metal–insulator transition`, and `materials physics`.
- Enhanced `index.html` front matter with a more specific `title` and `description` and inserted a `schema.org` `Person` JSON-LD block containing `name`, `alternateName`, `jobTitle`, `affiliation`, `knowsAbout`, `image`, and `sameAs` entries.
- Added a visible introductory paragraph on the homepage that explicitly declares this is the official homepage of `Hao Lu (Lu Hao)` and includes key terms (physicist, Giessen, VO₂ thin films, materials physics).
- These changes are purely content/metadata additions and do not change site layout or interactive behavior.

### Testing
- Attempted a local site build with `bundle exec jekyll build`, but the environment lacks the `jekyll` executable and the command failed with `bundler: command not found: jekyll`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b0aeffd88333aa8bf6a5f5b9fb4a)